### PR TITLE
feat: upgrade golangci-lint to v2.3.0 and fix code quality issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64.8
+          version: v2.3.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 linters:
   enable:
     - bodyclose
@@ -10,8 +12,6 @@ linters:
     - exhaustive
     - copyloopvar  # Go 1.24+ has enhanced loop variable semantics, but this linter still helps catch issues
     - gocritic
-    - gofmt
-    - goimports
     - makezero
     - misspell
     - nakedret
@@ -27,3 +27,8 @@ linters:
     - unparam
     # - wastedassign
     - whitespace
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/array.go
+++ b/array.go
@@ -49,6 +49,7 @@ func (k *ArrayKeyring) Keys() ([]string, error) {
 	return keys, nil
 }
 
+// GetMetadata returns an error as the ArrayKeyring backend does not support metadata access
 func (k *ArrayKeyring) GetMetadata(_ string) (Metadata, error) {
 	return Metadata{}, ErrMetadataNeedsCredentials
 }

--- a/cmd/keyring/main.go
+++ b/cmd/keyring/main.go
@@ -1,3 +1,4 @@
+// Package main provides a command-line interface for the keyring library.
 package main
 
 import (

--- a/file.go
+++ b/file.go
@@ -33,7 +33,7 @@ type fileKeyring struct {
 
 func (k *fileKeyring) resolveDir() (string, error) {
 	if k.dir == "" {
-		return "", fmt.Errorf("No directory provided for file keyring")
+		return "", fmt.Errorf("no directory provided for file keyring")
 	}
 
 	dir, err := ExpandTilde(k.dir)

--- a/keychain.go
+++ b/keychain.go
@@ -108,7 +108,7 @@ func (k *keychain) GetMetadata(key string) (Metadata, error) {
 		ModificationTime: results[0].ModificationDate,
 	}
 
-	debugf("Found metadata for %q", md.Item.Label)
+	debugf("Found metadata for %q", md.Label)
 
 	return md, nil
 }
@@ -127,7 +127,7 @@ func (k *keychain) updateItem(kc gokeychain.Keychain, kcItem gokeychain.Item, ac
 
 	results, err := gokeychain.QueryItem(queryItem)
 	if err != nil {
-		return fmt.Errorf("Failed to query keychain: %v", err)
+		return fmt.Errorf("failed to query keychain: %v", err)
 	}
 	if len(results) == 0 {
 		return errors.New("no results")
@@ -137,7 +137,7 @@ func (k *keychain) updateItem(kc gokeychain.Keychain, kcItem gokeychain.Item, ac
 	kcItem.SetAccess(nil)
 
 	if err := gokeychain.UpdateItem(queryItem, kcItem); err != nil {
-		return fmt.Errorf("Failed to update item in keychain: %v", err)
+		return fmt.Errorf("failed to update item in keychain: %v", err)
 	}
 
 	return nil

--- a/keyring.go
+++ b/keyring.go
@@ -110,17 +110,17 @@ type Keyring interface {
 }
 
 // ErrNoAvailImpl is returned by Open when a backend cannot be found.
-var ErrNoAvailImpl = errors.New("Specified keyring backend not available")
+var ErrNoAvailImpl = errors.New("specified keyring backend not available")
 
 // ErrKeyNotFound is returned by Keyring Get when the item is not on the keyring.
-var ErrKeyNotFound = errors.New("The specified item could not be found in the keyring")
+var ErrKeyNotFound = errors.New("the specified item could not be found in the keyring")
 
 // ErrMetadataNeedsCredentials is returned when Metadata is called against a
 // backend which requires credentials even to see metadata.
-var ErrMetadataNeedsCredentials = errors.New("The keyring backend requires credentials for metadata access")
+var ErrMetadataNeedsCredentials = errors.New("the keyring backend requires credentials for metadata access")
 
 // ErrMetadataNotSupported is returned when Metadata is not available for the backend.
-var ErrMetadataNotSupported = errors.New("The keyring backend does not support metadata access")
+var ErrMetadataNotSupported = errors.New("the keyring backend does not support metadata access")
 
 var (
 	// Debug specifies whether to print debugging output.

--- a/pass.go
+++ b/pass.go
@@ -4,6 +4,7 @@
 package keyring
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -47,7 +48,7 @@ func init() {
 		// fail if the pass program is not available
 		_, err = exec.LookPath(pass.passcmd)
 		if err != nil {
-			return nil, errors.New("The pass program is not available")
+			return nil, errors.New("the pass program is not available")
 		}
 
 		return pass, nil
@@ -61,7 +62,8 @@ type passKeyring struct {
 }
 
 func (k *passKeyring) pass(args ...string) *exec.Cmd {
-	cmd := exec.Command(k.passcmd, args...)
+	ctx := context.Background()
+	cmd := exec.CommandContext(ctx, k.passcmd, args...)
 	if k.dir != "" {
 		cmd.Env = append(os.Environ(), fmt.Sprintf("PASSWORD_STORE_DIR=%s", k.dir))
 	}

--- a/prompt.go
+++ b/prompt.go
@@ -10,6 +10,7 @@ import (
 // PromptFunc is a function used to prompt the user for a password.
 type PromptFunc func(string) (string, error)
 
+// TerminalPrompt prompts the user for input on the terminal, hiding the input for password security.
 func TerminalPrompt(prompt string) (string, error) {
 	fmt.Printf("%s: ", prompt)
 	b, err := term.ReadPassword(int(os.Stdin.Fd()))
@@ -20,6 +21,7 @@ func TerminalPrompt(prompt string) (string, error) {
 	return string(b), nil
 }
 
+// FixedStringPrompt returns a PromptFunc that always returns the provided fixed value.
 func FixedStringPrompt(value string) PromptFunc {
 	return func(_ string) (string, error) {
 		return value, nil

--- a/secretservice.go
+++ b/secretservice.go
@@ -50,7 +50,7 @@ type secretsKeyring struct {
 	session    *libsecret.Session
 }
 
-var errCollectionNotFound = errors.New("The collection does not exist. Please add a key first")
+var errCollectionNotFound = errors.New("the collection does not exist. Please add a key first")
 
 func decodeKeyringString(src string) string {
 	var dst strings.Builder


### PR DESCRIPTION
- Update GitHub Actions to use golangci-lint-action@v8 with v2.3.0
- Migrate .golangci.yml to version "2" format with separate formatters section
- Fix error handling by adding proper error checks for os.Setenv, os.Unsetenv, and os.RemoveAll
- Replace exec.Command with exec.CommandContext for better context handling
- Fix error message capitalization to follow Go conventions (lowercase)
- Remove redundant embedded field access in keychain.go
- Add context import to pass.go and pass_test.go

All golangci-lint issues resolved with 19+ enabled linters for comprehensive code quality enforcement.