### PR TITLE
fix: add apt-get update before package installation in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - run: sudo apt-get update
       - run: sudo apt-get install pass gnome-keyring dbus-x11
       - run: go test -race ./...
   mac:


### PR DESCRIPTION
Resolves 404 errors when installing packages in GitHub Actions by updating package lists before attempting installation.


## Error
```
Run sudo apt-get install pass gnome-keyring dbus-x11
  sudo apt-get install pass gnome-keyring dbus-x11
  shell: /usr/bin/bash -e {0}
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  gcr gcr4 gnome-keyring-pkcs11 gstreamer1.0-gl gstreamer1.0-plugins-base
  libcairo-script-interpreter2 libcdparanoia0 libegl-mesa0 libegl1 libgck-1-0
  libgck-2-2 libgcr-4-4 libgcr-base-3-1 libgcr-ui-3-1 libgles2
  libgraphene-1.0-0 libgstreamer-gl1.0-0 libgstreamer-plugins-base1.0-0
  libgtk-4-1 libgtk-4-bin libgtk-4-common libgtk-4-media-gstreamer libopus0
  liborc-0.4-0t64 libpam-gnome-keyring libqrencode4 librsvg2-2 librsvg2-common
  libsecret-1-0 libsecret-common libtheora0 libvisual-0.4-0 libvorbisenc2
  pinentry-gnome3 qrencode wl-clipboard xclip
Suggested packages:
  gvfs libvisual-0.4-plugins opus-tools librsvg2-bin libxml-simple-perl python
  pinentry-doc
The following NEW packages will be installed:
  dbus-x11 gcr gcr4 gnome-keyring gnome-keyring-pkcs11 gstreamer1.0-gl
  gstreamer1.0-plugins-base libcairo-script-interpreter2 libcdparanoia0
  libegl-mesa0 libegl1 libgck-1-0 libgck-2-2 libgcr-4-4 libgcr-base-3-1
  libgcr-ui-3-1 libgles2 libgraphene-1.0-0 libgstreamer-gl1.0-0
  libgstreamer-plugins-base1.0-0 libgtk-4-1 libgtk-4-bin libgtk-4-common
  libgtk-4-media-gstreamer libopus0 liborc-0.4-0t64 libpam-gnome-keyring
  libqrencode4 librsvg2-2 librsvg2-common libsecret-1-0 libsecret-common
  libtheora0 libvisual-0.4-0 libvorbisenc2 pass pinentry-gnome3 qrencode
  wl-clipboard xclip
0 upgraded, 40 newly installed, 0 to remove and 2 not upgraded.
Need to get 15.2 MB of archives.
After this operation, 56.4 MB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 dbus-x11 amd64 1.14.10-4ubuntu4.1 [23.3 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgck-2-2 amd64 4.2.0-5 [77.0 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgcr-4-4 amd64 4.2.0-5 [192 kB]
Get:5 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libcairo-script-interpreter2 amd64 1.18.0-3build1 [60.3 kB]
Get:6 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgraphene-1.0-0 amd64 1.10.8-3build2 [46.2 kB]
Get:7 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgles2 amd64 1.7.0-1build1 [17.1 kB]
Ign:8 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-common all 4.14.5+ds-0ubuntu0.4
Ign:9 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-1 amd64 4.14.5+ds-0ubuntu0.4
Get:10 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsecret-common all 0.21.4-1build3 [4962 B]
Get:11 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsecret-1-0 amd64 0.21.4-1build3 [116 kB]
Ign:8 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-common all 4.14.5+ds-0ubuntu0.4
Ign:9 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-1 amd64 4.14.5+ds-0ubuntu0.4
Get:12 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 gcr4 amd64 4.2.0-5 [42.9 kB]
Get:13 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgck-1-0 amd64 3.41.2-1build3 [79.9 kB]
Get:14 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgcr-base-3-1 amd64 3.41.2-1build3 [202 kB]
Get:15 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgcr-ui-3-1 amd64 3.41.2-1build3 [124 kB]
Get:16 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 gcr amd64 3.41.2-1build3 [60.4 kB]
Err:8 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-common all 4.14.5+ds-0ubuntu0.4
  404  Not Found [IP: 40.81.13.82 80]
Get:17 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 pinentry-gnome3 amd64 1.2.1-3ubuntu5 [38.3 kB]
Get:18 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 gnome-keyring amd64 46.1-2build1 [639 kB]
Err:9 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-1 amd64 4.14.5+ds-0ubuntu0.4
  404  Not Found [IP: 40.81.13.82 80]
Get:19 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 gnome-keyring-pkcs11 amd64 46.1-2build1 [27.9 kB]
Get:20 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libegl-mesa0 amd64 25.0.7-0ubuntu0.24.04.1 [124 kB]
Get:21 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libegl1 amd64 1.7.0-1build1 [28.7 kB]
Get:22 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 liborc-0.4-0t64 amd64 1:0.4.38-1ubuntu0.1 [207 kB]
Ign:23 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgstreamer-plugins-base1.0-0 amd64 1.24.2-1ubuntu0.2
Ign:23 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 libgstreamer-plugins-base1.0-0 amd64 1.24.2-1ubuntu0.2
Ign:24 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgstreamer-gl1.0-0 amd64 1.24.2-1ubuntu0.2
Ign:24 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 libgstreamer-gl1.0-0 amd64 1.24.2-1ubuntu0.2
Ign:25 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gstreamer1.0-gl amd64 1.24.2-1ubuntu0.2
Ign:23 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libgstreamer-plugins-base1.0-0 amd64 1.24.2-1ubuntu0.2
Err:23 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libgstreamer-plugins-base1.0-0 amd64 1.24.2-1ubuntu0.2
  404  Not Found [IP: 40.81.13.82 80]
Ign:25 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 gstreamer1.0-gl amd64 1.24.2-1ubuntu0.2
Get:26 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libcdparanoia0 amd64 3.10.2+debian-14build3 [48.5 kB]
Get:27 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libopus0 amd64 1.4-1build1 [208 kB]
Ign:24 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libgstreamer-gl1.0-0 amd64 1.24.2-1ubuntu0.2
Err:24 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libgstreamer-gl1.0-0 amd64 1.24.2-1ubuntu0.2
  404  Not Found [IP: 40.81.13.82 80]
Get:28 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtheora0 amd64 1.1.1+dfsg.1-16.1build3 [211 kB]
Ign:25 https://security.ubuntu.com/ubuntu noble-updates/main amd64 gstreamer1.0-gl amd64 1.24.2-1ubuntu0.2
Err:25 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 gstreamer1.0-gl amd64 1.24.2-1ubuntu0.2
  404  Not Found [IP: 40.81.13.82 80]
Get:29 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libvisual-0.4-0 amd64 0.4.2-2build1 [115 kB]
Get:30 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libvorbisenc2 amd64 1.3.7-1build3 [80.8 kB]
Ign:31 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gstreamer1.0-plugins-base amd64 1.24.2-1ubuntu0.2
Ign:31 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 gstreamer1.0-plugins-base amd64 1.24.2-1ubuntu0.2
Ign:32 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-bin amd64 4.14.5+ds-0ubuntu0.4
Ign:32 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-bin amd64 4.14.5+ds-0ubuntu0.4
Ign:33 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-media-gstreamer amd64 4.14.5+ds-0ubuntu0.4
Ign:31 https://security.ubuntu.com/ubuntu noble-updates/main amd64 gstreamer1.0-plugins-base amd64 1.24.2-1ubuntu0.2
Err:31 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 gstreamer1.0-plugins-base amd64 1.24.2-1ubuntu0.2
  404  Not Found [IP: 40.81.13.82 80]
Ign:33 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-media-gstreamer amd64 4.14.5+ds-0ubuntu0.4
Get:34 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libpam-gnome-keyring amd64 46.1-2build1 [17.4 kB]
Get:35 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libqrencode4 amd64 4.1.1-1build2 [25.0 kB]
Err:32 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-bin amd64 4.14.5+ds-0ubuntu0.4
  404  Not Found [IP: 40.81.13.82 80]
Get:36 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 librsvg2-2 amd64 2.58.0+dfsg-1build1 [2135 kB]
Err:33 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-media-gstreamer amd64 4.14.5+ds-0ubuntu0.4
  404  Not Found [IP: 40.81.13.82 80]
Get:37 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 librsvg2-common amd64 2.58.0+dfsg-1build1 [11.8 kB]
Get:38 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 pass all 1.7.4-6 [34.5 kB]
Get:39 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 qrencode amd64 4.1.1-1build2 [26.1 kB]
Get:40 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 wl-clipboard amd64 2.2.1-1build1 [33.4 kB]
Get:41 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 xclip amd64 0.13-3 [17.6 kB]
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/main/g/gtk4/libgtk-4-common_4.14.5%2bds-0ubuntu0.4_all.deb  404  Not Found [IP: 40.81.13.82 80]
Fetched 5077 kB in 5s (1056 kB/s)
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/main/g/gtk4/libgtk-4-1_4.14.5%2bds-0ubuntu0.4_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/g/gst-plugins-base1.0/libgstreamer-plugins-base1.0-0_1.24.2-1ubuntu0.2_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.2-1ubuntu0.2_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/g/gst-plugins-base1.0/gstreamer1.0-gl_1.24.2-1ubuntu0.2_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/g/gst-plugins-base1.0/gstreamer1.0-plugins-base_1.24.2-1ubuntu0.2_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/main/g/gtk4/libgtk-4-bin_4.14.5%2bds-0ubuntu0.4_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/main/g/gtk4/libgtk-4-media-gstreamer_4.14.5%2bds-0ubuntu0.4_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```