### PR TITLE
Upgrade to Go 1.26

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,4 +15,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.4.0
+          version: v2.11.4

--- a/array.go
+++ b/array.go
@@ -42,7 +42,7 @@ func (k *ArrayKeyring) Remove(key string) error {
 
 // Keys provides a slice of all Item keys on the Keyring.
 func (k *ArrayKeyring) Keys() ([]string, error) {
-	var keys = []string{}
+	keys := make([]string, 0, len(k.items))
 	for key := range k.items {
 		keys = append(keys, key)
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   keyring:
-    image: golang:1.25
+    image: golang:1.26
     volumes:
       - .:/usr/local/src/keyring
     working_dir: /usr/local/src/keyring

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vincentclee/keyring/v2
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4


### PR DESCRIPTION
# Upgrade to Go 1.26

## Summary

Upgrades the project from Go 1.25 to Go 1.26 and resolves a `prealloc` lint issue surfaced by the updated linter.

## Changes

### Go 1.26 Upgrade
- **`go.mod`**: Bumped Go version from `1.25.0` → `1.26.0`
- **`docker-compose.yml`**: Updated Docker image from `golang:1.25` → `golang:1.26`
- **`.github/workflows/lint.yml`**: Upgraded `golangci-lint` from `v2.4.0` → `v2.11.4`

### Lint Fix
- **`array.go`**: Preallocated `keys` slice in `ArrayKeyring.Keys()` with `make([]string, 0, len(k.items))` to satisfy the `prealloc` linter rule, avoiding unnecessary slice growth during iteration.

## Testing

- `golangci-lint run ./...` passes with 0 issues.
